### PR TITLE
カスタム変数が廃止になるため、カスタムディメンションを使用するようにメソッドを修正しました

### DIFF
--- a/Controller/Component/AbTestComponent.php
+++ b/Controller/Component/AbTestComponent.php
@@ -140,6 +140,32 @@ class AbTestComponent extends Component
     }
 
     /**
+     * Get Universal analytics's JS code for custom value.
+     *
+     * @access public
+     * @return string $result
+     */
+    public function getUniversalAnalyticsDimensionVar()
+    {
+        $result = "";
+        $abTests = $this->readCookieAll();
+        if (!empty($abTests)) {
+            $keys = array();
+            foreach ($abTests as $key => $value) {
+                $result .= "ga('set','dimention" . $value['index'] . "','{$value['value']}');".PHP_EOL;
+                $keys[] = $value['index'];
+            }
+
+            // Write log, if same customValueIndex has set in as session.
+            if (count($abTests) != count(array_unique($keys))) {
+                $this->log("[AbTestPlugin] Same customValueIndex has been set in a session. customValueIndex should be 1 to $this->maxCustomIndexValue by unique.");
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Set abtest cookie.
      *
      * @access private

--- a/View/Helper/AbTestHelper.php
+++ b/View/Helper/AbTestHelper.php
@@ -53,5 +53,17 @@ class AbTestHelper extends AppHelper
     {
         return $this->abTestComponent->getAnalyticsCustomVar();
     }
+
+    /**
+     * Get Universal analytics's JS code for custom value.
+     * (Wrapper methodo of AbTestComponent).
+     *
+     * @access public
+     * @return string $result
+     */
+    public function getUniversalAnalyticsDimensionVar ()
+    {
+        return $this->abTestComponent->getUniversalAnalyticsDimensionVar();
+    }
 }
 


### PR DESCRIPTION
closes #12536

http://iero.uluru.cc/issues/12536

参考URL
https://developers.google.com/analytics/devguides/collection/upgrade/reference/gajs-analyticsjs?hl=ja#custom-vars
http://www.seohacks.net/blog/tool/universal_analytics2/#2
